### PR TITLE
do not merge -- checkpoint alert signal on 'reset center'

### DIFF
--- a/firmware/src/src/defines.h
+++ b/firmware/src/src/defines.h
@@ -17,6 +17,7 @@
 #define CALCULATE_PERIOD 6666   // (us) 150hz IMU calculations
 #define PWM_FREQUENCY 50        // (ms) PWM Period
 #define UIRESPONSIVE_TIME 10000 // (ms) 10Seconds without an ack data will stop;
+#define RESET_PULSE_PERIOD 500000 // (us) pulse duration for the reset signal to TX
 
 // Analog Filters 1 Euro Filter
 #define AN_CH_CNT 4

--- a/firmware/src/src/sense.cpp
+++ b/firmware/src/src/sense.cpp
@@ -433,12 +433,32 @@ void calculate_Thread()
         int tltch = trkset.tiltCh();
         int rllch = trkset.rollCh();
         int panch = trkset.panCh();
+        int alertch = trkset.alertCh();
         if(tltch > 0)
             channel_data[tltch - 1] = trpOutputEnabled == true ? tiltout_ui : trkset.Tlt_cnt();
         if(rllch > 0)
             channel_data[rllch - 1] = trpOutputEnabled == true ? rollout_ui : trkset.Rll_cnt();
         if(panch > 0)
             channel_data[panch - 1] = trpOutputEnabled == true ? panout_ui : trkset.Pan_cnt();
+
+        // TODO what is trpOutputEnabled?
+        static float pulsetimer=0;
+        static bool sendingresetpulse = false;
+        if (alertch > 0) {
+            // Synthesize a pulse indicating recenter started
+            channel_data[alertch - 1] = TrackerSettings::MIN_PWM;
+            if (butdnw) {
+                sendingresetpulse = true;
+                pulsetimer=0;
+            }
+            if (sendingresetpulse) {
+                channel_data[alertch - 1] = TrackerSettings::MAX_PWM;
+                pulsetimer += (float)CALCULATE_PERIOD / 1000000.0;
+                if(pulsetimer > TrackerSettings::RECENTER_PULSE_DURATION) {
+                    sendingresetpulse = false;
+                }
+            }
+        }
 
         // 9) Set the PPM Outputs
         for(int i=0;i<PpmOut_getChnCount();i++) {

--- a/firmware/src/src/trackersettings.cpp
+++ b/firmware/src/src/trackersettings.cpp
@@ -48,6 +48,7 @@ TrackerSettings::TrackerSettings()
     tltch = DEF_TILT_CH;
     rllch = DEF_ROLL_CH;
     panch = DEF_PAN_CH;
+    alertch = DEF_ALERT_CH;
 
     // Servo Reversed bits
     servoreverse = 0x00;
@@ -415,6 +416,17 @@ void TrackerSettings::setRollCh(int value)
         rllch = (int)value;
 }
 
+int TrackerSettings::alertCh() const
+{
+    return alertch;
+}
+
+void TrackerSettings::setAlertCh(int value)
+{
+    if((value > 0 && value < 17) || value == -1)
+        alertch = (int)value;
+}
+
 //----------------------------------------------------------------------------------------
 // Remappable Buttons + PPM Output Pin + Bluetooth
 
@@ -770,6 +782,7 @@ void TrackerSettings::loadJSONSettings(DynamicJsonDocument &json)
     v = json["rllch"]; if(!v.isNull()) setRollCh(v);
     v = json["tltch"]; if(!v.isNull()) setTiltCh(v);
     v = json["panch"]; if(!v.isNull()) setPanCh(v);
+    v = json["alertch"]; if(!v.isNull()) setAlertCh(v);
 
 // Servo Reversed
     v = json["servoreverse"]; if(!v.isNull()) setServoreverse(v);
@@ -954,6 +967,7 @@ void TrackerSettings::setJSONSettings(DynamicJsonDocument &json)
     json["rllch"] = rllch;
     json["panch"] = panch;
     json["tltch"] = tltch;
+    json["alertch"] = alertch;
 
 // Servo Reverse Channels
     json["servoreverse"] = servoreverse;

--- a/firmware/src/src/trackersettings.h
+++ b/firmware/src/src/trackersettings.h
@@ -105,6 +105,7 @@ public:
     static constexpr bool DEF_RESET_ON_TILT = false;
     static constexpr float RESET_ON_TILT_TIME = 1.5; // Seconds to complete a head tilt
     static constexpr float RESET_ON_TILT_AFTER = 1.0; // How long after the tilt to reset
+    static constexpr float RECENTER_PULSE_DURATION = 0.5; // (sec) pulse width of recenter signal to tx
     static constexpr int DEF_PPM_OUT = 10; // Random choice
     static constexpr int DEF_PPM_IN = -1;
     static constexpr int PPM_CENTER = 1500;
@@ -118,6 +119,7 @@ public:
     static constexpr int DEF_TILT_CH = -1;
     static constexpr int DEF_ROLL_CH = -1;
     static constexpr int DEF_PAN_CH = -1;
+    static constexpr int DEF_ALERT_CH = -1;
     static constexpr int DEF_LP_PAN = 75;
     static constexpr int DEF_LP_TLTRLL = 75;
     static constexpr int DEF_PWM_A0_CH = -1;
@@ -200,6 +202,9 @@ public:
 
     int rollCh() const;
     void setRollCh(int value);
+
+    int alertCh() const;
+    void setAlertCh(int value);
 
     int ppmOutPin() const;
     void setPpmOutPin(int value);
@@ -348,7 +353,7 @@ private:
     int tlt_min,tlt_max,tlt_cnt;
     int pan_min,pan_max,pan_cnt;
     float rll_gain,tlt_gain,pan_gain;
-    int tltch,rllch,panch;
+    int tltch,rllch,panch,alertch;
 
     // Calibration
     float magxoff, magyoff, magzoff;


### PR DESCRIPTION
We add another configured channel that will send a 0.5sec pulse out on that channel whenever a reset center occurs.  This is typically used to play an audio on the TX 'camera centered' -- the signal is inband and should work on BT and direct trainer channel.