### PR TITLE
LSM6DS3 gyro init was setting hasMag instead of hasGyr to true

### DIFF
--- a/firmware/src/src/sense.cpp
+++ b/firmware/src/src/sense.cpp
@@ -279,7 +279,7 @@ int sense_Init()
     LOG_ERR("Unable to init LSM6DS3\n");
     return -1;
   } else {
-    hasMag = true;
+    hasGyr = true;
   }
 #endif
 


### PR DESCRIPTION
Correct LSM6DS3 init check to set hasGyr to true instead of hasMag. This was preventing the gyro from calibrating.

This was found after noticing that the xiao-ble-nrf52840-sense was constantly drifting. This appears to have solved the drift issues I was encountering. 