### PR TITLE
Min PPM input sync 400usec so that we can connect two headtracker via PPM (from master)

### DIFF
--- a/firmware/src/src/PPMIn.cpp
+++ b/firmware/src/src/PPMIn.cpp
@@ -63,8 +63,9 @@ ISR_DIRECT_DECLARE(PPMInGPIOTE_ISR)
     // Read Timer Captured Value
     uint32_t time = PPMIN_TIMER->CC[PPMIN_TMRCOMP_CH];
 
-    // Long pulse = Start.. Minimum frame sync is 3ms.. Giving a 10us leway
-    if (time > 2990) {
+    // Long pulse = Start.. Minimum frame sync is 400us.. Giving a 10us leway 
+    // See https://headtracker.gitbook.io/head-tracker-v2.2/settings/gui-settings/output
+    if(time > 390) {
       // Copy all data to another buffer so it can be read complete
       for (int i = 0; i < 16; i++) {
         ch_count = isrch_count;


### PR DESCRIPTION
Reduced ppm min sync for inpout so that we can connect two headtracker via PPM (e.g. one for head and one for flight stick).

See: https://github.com/headtracker/HeadTracker/issues/217

The problem is that expected input sync must be >3000usec but in the GUI you can only configure up to 80usec for the output. So two headtracker can not be connected via PPM.

I need it for my FPV Cockpit Controller project at https://github.com/feffe81/fpv-cockpit-controller